### PR TITLE
NOJIRA: handle optional `parameters` and `parameterGroups` properties in the template model

### DIFF
--- a/firebase_remote_config/models.py
+++ b/firebase_remote_config/models.py
@@ -139,9 +139,9 @@ class ListVersionsResponse(BaseModel):
 # https://firebase.google.com/docs/reference/remote-config/rest/v1/RemoteConfig
 class RemoteConfigTemplate(BaseModel):
     conditions: List[RemoteConfigCondition]
-    parameters: Dict[str, RemoteConfigParameter]
+    parameters: Optional[Dict[str, RemoteConfigParameter]] = Field(default_factory=dict)
     version: Optional[Version] = None
-    parameterGroups: Dict[str, RemoteConfigParameterGroup]
+    parameterGroups: Optional[Dict[str, RemoteConfigParameterGroup]] = Field(default_factory=dict)
 
 
 # https://firebase.google.com/docs/reference/remote-config/rest/v1/projects.remoteConfig/listVersions#query-parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "firebase-remote-config"
-version = "0.1.17"
+version = "0.1.18"
 description = "Firebase Remote Config SDK"
 authors = [
   { name="Dmitry Kaysin", email="kaysin.dmitry@gmail.com" }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,6 +121,81 @@ def test_crd():
     assert len(config.template.parameters["test_param_1"].conditionalValues.values()) == 2
     assert config.template.parameters["new_test_param"].conditionalValues == {}
 
+def test_no_parameters():
+    # this is a valid config even if there are no parameters
+    config = rc.RemoteConfig(
+        template=rc.RemoteConfigTemplate(
+            conditions=[
+                rc.RemoteConfigCondition(
+                    name="condition_1",
+                    expression="app.version.>(['1.0.0'])",
+                    tagColor=rc.TagColor.GREEN,
+                ),
+                rc.RemoteConfigCondition(
+                    name="condition_2",
+                    expression="device.language in ['en-US', 'de-DE']",
+                    tagColor=rc.TagColor.BLUE,
+                ),
+            ],
+            parameterGroups={
+                "pg1": rc.RemoteConfigParameterGroup(
+                    parameters={
+                        "test_param_1": rc.RemoteConfigParameter(
+                            defaultValue=rc.RemoteConfigParameterValue(value="test_value_1_default"),
+                            valueType=rc.ParameterValueType.STRING,
+                        ),
+                        "test_param_2": rc.RemoteConfigParameter(
+                            defaultValue=rc.RemoteConfigParameterValue(value="test_value_2_default"),
+                            valueType=rc.ParameterValueType.STRING,
+                        ),
+                    },
+                ),
+            },
+        ),
+        etag="test",
+    )
+    assert len(config.template.parameterGroups) == 1
+
+    parameter_names = [param_key for param_key, _ in config.iterate_parameter_items()]
+    assert len(parameter_names) == 2
+    assert "test_param_1" in parameter_names
+    assert "test_param_2" in parameter_names
+
+    # this is a valid config even if there are no parameter groups
+    config = rc.RemoteConfig(
+        template=rc.RemoteConfigTemplate(
+            conditions=[
+                rc.RemoteConfigCondition(
+                    name="condition_1",
+                    expression="app.version.>(['1.0.0'])",
+                    tagColor=rc.TagColor.GREEN,
+                ),
+                rc.RemoteConfigCondition(
+                    name="condition_2",
+                    expression="device.language in ['en-US', 'de-DE']",
+                    tagColor=rc.TagColor.BLUE,
+                ),
+            ],
+            parameters={
+                "test_param_1": rc.RemoteConfigParameter(
+                    defaultValue=rc.RemoteConfigParameterValue(value="test_value_1_default"),
+                    valueType=rc.ParameterValueType.STRING,
+                ),
+                "test_param_2": rc.RemoteConfigParameter(
+                    defaultValue=rc.RemoteConfigParameterValue(value="test_value_2_default"),
+                    valueType=rc.ParameterValueType.STRING,
+                ),
+            },
+        ),
+        etag="test",
+    )
+    assert len(config.template.parameterGroups) == 0
+
+    parameter_names = [param_key for param_key, _ in config.iterate_parameter_items()]
+    assert len(parameter_names) == 2
+    assert "test_param_1" in parameter_names
+    assert "test_param_2" in parameter_names
+
 def test_value_to_type():
     assert rc.value_to_type("test") == rc.ParameterValueType.STRING
     assert rc.value_to_type("true") == rc.ParameterValueType.STRING


### PR DESCRIPTION
Fix for https://github.com/apprevenew-com/firebase-remote-config-python/issues/2